### PR TITLE
Rename BottomSheet prop for consistent visibility handling

### DIFF
--- a/src/components/BottomSheet.jsx
+++ b/src/components/BottomSheet.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import Modal from 'react-native-modal';
 
-const BottomSheet = ({ isVisible, onClose, title, children }) => {
+// Accept a `visible` prop for consistency with callers
+const BottomSheet = ({ visible, onClose, title, children }) => {
   return (
     <Modal
-      isVisible={isVisible}
+      isVisible={visible}
       onBackdropPress={onClose}
       onSwipeComplete={onClose}
       swipeDirection="down"


### PR DESCRIPTION
## Summary
- rename BottomSheet `isVisible` prop to `visible`
- ensure modal uses new `visible` prop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f4ebc69c832ba7728254987cb3ef