### PR TITLE
feat: allow MessageGroup to handle participant presses

### DIFF
--- a/src/components/MessageGroup.jsx
+++ b/src/components/MessageGroup.jsx
@@ -8,7 +8,7 @@ import DateSeparator from './DateSeparator';
  * A message group handles rendering one or more consecutive messages
  * from the same participant, optionally separated by date.
  */
-const MessageGroup = ({ group, onReact, onReactionPress }) => {
+const MessageGroup = ({ group, onReact, onReactionPress, onParticipantPress }) => {
   if (!group) return null;
 
   return (
@@ -19,11 +19,12 @@ const MessageGroup = ({ group, onReact, onReactionPress }) => {
       )}
 
       {/* Main message bubble */}
-      <MessageBubble 
-        message={group} 
+      <MessageBubble
+        message={group}
         isGrouped={group.isGrouped || false}
         onReact={onReact}
         onReactionPress={onReactionPress}
+        onParticipantPress={onParticipantPress}
       />
     </View>
   );

--- a/src/screens/ChatScreen.jsx
+++ b/src/screens/ChatScreen.jsx
@@ -210,7 +210,8 @@ const MemoizedMessageGroup = memo(MessageGroup, (prevProps, nextProps) => {
   return (
     prevProps.group.uuid === nextProps.group.uuid &&
     prevProps.group.messages?.length === nextProps.group.messages?.length &&
-    JSON.stringify(prevProps.group.reactions) === JSON.stringify(nextProps.group.reactions)
+    JSON.stringify(prevProps.group.reactions) === JSON.stringify(nextProps.group.reactions) &&
+    prevProps.onParticipantPress === nextProps.onParticipantPress
   );
 });
 


### PR DESCRIPTION
## Summary
- add `onParticipantPress` to `MessageGroup`
- memo comparator includes new callback

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898f4ecd1e4832b8306e76d898cd7d2