### PR TITLE
feat: support replying to messages

### DIFF
--- a/src/api/messages.js
+++ b/src/api/messages.js
@@ -95,12 +95,22 @@ export const fetchUpdatedMessages = async (since) => {
 
 /**
  * Send a new message
- * @param {string} text - Message text content
+ * @param {Object} payload - Message payload
+ * @param {string} payload.text - Message text content
+ * @param {string} [payload.replyToMessage] - UUID of the message being replied to
  */
-export const sendMessage = async (text) => {
+export const sendMessage = async (payload) => {
   try {
-    const res = await axios.post(`${BASE_URL}/messages/new`, { text });
-    return res.data;
+    const res = await axios.post(`${BASE_URL}/messages/new`, payload);
+
+    const message = res.data;
+
+    // Ensure reply metadata is present in response if provided in payload
+    if (payload?.replyToMessage && !message.replyToMessage) {
+      message.replyToMessage = { uuid: payload.replyToMessage };
+    }
+
+    return message;
   } catch (err) {
     console.error('❌ Failed to send message:', err);
     throw new Error(`Failed to send message: ${err.message}`);

--- a/src/components/InputBar.jsx
+++ b/src/components/InputBar.jsx
@@ -31,7 +31,13 @@ const InputBar = () => {
         ...(isReplying && replyTo ? { replyToMessage: replyTo.uuid } : {}),
       };
 
-      const newMessage = await sendMessage(payload.text); // NOTE: adjust if you customize API
+      const newMessage = await sendMessage(payload);
+
+      // Ensure reply metadata is preserved locally
+      if (payload.replyToMessage && !newMessage.replyToMessage) {
+        newMessage.replyToMessage = replyTo;
+      }
+
       addMessage(newMessage);
       setText('');
       cancelReply();


### PR DESCRIPTION
## Summary
- allow sendMessage to post payload with optional reply reference and return reply metadata
- pass full payload from InputBar to sendMessage and preserve reply object for added messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f4f25d24832b93f80a1ca5133ba8