### PR TITLE
Consolidate theme exports and add hook tests

### DIFF
--- a/src/constants/__snapshots__/theme.test.js.snap
+++ b/src/constants/__snapshots__/theme.test.js.snap
@@ -1,0 +1,41 @@
+exports[`useTheme returns light theme when color scheme is light 1`] = `
+Object {
+  "background": "#FFFFFF",
+  "border": "#C6C6C8",
+  "borderLight": "#E5E5EA",
+  "error": "#FF3B30",
+  "info": "#007AFF",
+  "primary": "#007AFF",
+  "primaryDark": "#0056CC",
+  "primaryLight": "#4A9EFF",
+  "secondary": "#8E8E93",
+  "success": "#34C759",
+  "surface": "#F2F2F7",
+  "surfaceSecondary": "#FFFFFF",
+  "text": "#000000",
+  "textMuted": "#C7C7CC",
+  "textSecondary": "#8E8E93",
+  "warning": "#FF9500",
+}
+`;
+
+exports[`useTheme returns dark theme when color scheme is dark 1`] = `
+Object {
+  "background": "#000000",
+  "border": "#38383A",
+  "borderLight": "#48484A",
+  "error": "#FF3B30",
+  "info": "#007AFF",
+  "primary": "#0A84FF",
+  "primaryDark": "#0056CC",
+  "primaryLight": "#409CFF",
+  "secondary": "#8E8E93",
+  "success": "#34C759",
+  "surface": "#1C1C1E",
+  "surfaceSecondary": "#2C2C2E",
+  "text": "#FFFFFF",
+  "textMuted": "#48484A",
+  "textSecondary": "#8E8E93",
+  "warning": "#FF9500",
+}
+`;

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -2,7 +2,7 @@
 // src/constants/theme.js
 import { useColorScheme } from 'react-native';
 
-const lightTheme = {
+export const lightTheme = {
   colors: {
     primary: '#007AFF',
     primaryLight: '#4A9EFF',
@@ -78,7 +78,7 @@ const lightTheme = {
   },
 };
 
-const darkTheme = {
+export const darkTheme = {
   ...lightTheme,
   colors: {
     ...lightTheme.colors,

--- a/src/constants/theme.test.js
+++ b/src/constants/theme.test.js
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-native';
+import { useTheme, lightTheme, darkTheme } from './theme';
+import { useColorScheme as mockUseColorScheme } from 'react-native';
+
+jest.mock('react-native', () => {
+  const actual = jest.requireActual('react-native');
+  return {
+    ...actual,
+    useColorScheme: jest.fn(),
+  };
+});
+
+describe('useTheme', () => {
+  it('returns light theme when color scheme is light', () => {
+    mockUseColorScheme.mockReturnValue('light');
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.colors).toMatchSnapshot();
+    expect(result.current).toEqual(lightTheme);
+  });
+
+  it('returns dark theme when color scheme is dark', () => {
+    mockUseColorScheme.mockReturnValue('dark');
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.colors).toMatchSnapshot();
+    expect(result.current).toEqual(darkTheme);
+  });
+});
+


### PR DESCRIPTION
## Summary
- unify light and dark theme exports and provide useTheme hook
- add snapshot tests validating useTheme selects appropriate theme

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo: not found)*
- `npm run typecheck` *(fails: missing modules)*
- manual node scripts show correct light and dark theme colors

------
https://chatgpt.com/codex/tasks/task_e_68991db5c2e8832b824fd2eeedf1aa1c