### PR TITLE
fix: correct apostrophe in error boundary fallback

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -58,7 +58,7 @@ class ErrorBoundary extends React.Component {
           <View style={styles.content}>
             <Text style={styles.title}>Oops! Something went wrong</Text>
             <Text style={styles.message}>
-              We&apos;re sorry, but something unexpected happened. Please try again.
+              {"We're sorry, but something unexpected happened. Please try again."}
             </Text>
             
             {/* Show error details in development */}


### PR DESCRIPTION
## Summary
- fix HTML entity in `ErrorBoundary` fallback text to use proper apostrophe so it renders correctly on native platforms

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: No matching version for @testing-library/jest-native@^5.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68995b54fc38832bba95590b844861c1