### PR TITLE
Fix date separator for first message

### DIFF
--- a/src/components/__tests__/date-separator.test.jsx
+++ b/src/components/__tests__/date-separator.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import MessageGroup from '../MessageGroup';
+import { groupMessages } from '../../utils/groupMessages';
+import { formatDate } from '../../utils/formatDate';
+
+describe('MessageGroup date separator', () => {
+  const messages = [
+    {
+      uuid: '1',
+      text: 'First',
+      participant: { uuid: 'u1' },
+      createdAt: '2023-01-01T10:00:00Z',
+    },
+    {
+      uuid: '2',
+      text: 'Second',
+      participant: { uuid: 'u2' },
+      createdAt: '2023-01-02T10:00:00Z',
+    },
+  ];
+  const grouped = groupMessages(messages);
+
+  it('does not render date header for first message', () => {
+    const { queryByText } = render(<MessageGroup group={grouped[0]} />);
+    expect(queryByText(formatDate(messages[0].createdAt))).toBeNull();
+  });
+
+  it('renders date header for subsequent messages on new days', () => {
+    const { getByText } = render(<MessageGroup group={grouped[1]} />);
+    expect(getByText(formatDate(messages[1].createdAt))).toBeTruthy();
+  });
+});

--- a/src/utils/groupMessages.js
+++ b/src/utils/groupMessages.js
@@ -18,7 +18,7 @@ export function groupMessages(messages) {
     grouped.push({
       ...current,
       isGrouped: isSameSender && isSameDayFlag,
-      dateSeparator: !isSameDayFlag,
+      dateSeparator: i > 0 && !isSameDayFlag,
     });
   }
 


### PR DESCRIPTION
## Summary
- avoid date header before the first message
- add regression test for date separator behaviour

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: No matching version found for @testing-library/jest-native@^5.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68995b57ef28832b910e3c0473cfbcdc